### PR TITLE
docs: add guidelines for creating pull requests in markdown

### DIFF
--- a/.pochi/workflows/create-pr.md
+++ b/.pochi/workflows/create-pr.md
@@ -1,0 +1,11 @@
+Please help create a PR for the current staging changes, following these guidelines:
+
+- If there are no staging changes but there are uncommitted changes, please stage them first.
+- Create a branch name based on the current git diff status.
+- Write a meaningful commit message/PR title.
+- Use the gh CLI to create a PR.
+- When running the push operation, it might be aborted due to a husky pre-push hook. For formatting issues, amend the files and try again. For other issues, try to resolve them as much as possible.
+- The base branch for the PR should always be `main`.
+- Always push the branch to the remote repository before creating the PR.
+
+When creating PR with markdown description, pay attention to escape backticks, otherwise it will be executed as command substitution in the shell.


### PR DESCRIPTION
This pull request adds documentation to `.pochi/workflows/create-pr.md` to guide developers on creating pull requests effectively.

Key additions:

* Added step-by-step guidelines for creating a pull request, including staging uncommitted changes, naming branches, writing commit messages, and using the `gh` CLI.
* Included instructions for handling potential issues during the push operation, such as formatting errors or other conflicts.
* Highlighted the importance of escaping backticks in markdown descriptions to prevent unintended shell command execution.