### PR TITLE
chore: remove Chinese content

### DIFF
--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -115,11 +115,6 @@ export const socialLinks = [
     icon: "Twitter",
   },
   {
-    href: "https://space.bilibili.com/72605744",
-    label: "Bilibili",
-    icon: "Play",
-  },
-  {
     href: "https://github.com/Sma1lboy",
     label: "GitHub",
     icon: "Github",


### PR DESCRIPTION
This PR removes all Chinese content from the repository, including a social media link and any other instances of Chinese text. This is to ensure the repository is fully in English.