### PR TITLE
Create new webpage entry with updated design

### DIFF
--- a/src/components/brutalist/BrutalistExperience.tsx
+++ b/src/components/brutalist/BrutalistExperience.tsx
@@ -1,0 +1,135 @@
+import { sortedExperiences } from '@/constants/experiences';
+import { ExternalLink } from 'lucide-react';
+
+const TYPE_COLORS: Record<string, string> = {
+  work: 'bg-green-500',
+  internship: 'bg-blue-500',
+  education: 'bg-purple-500',
+  project: 'bg-yellow-400',
+  award: 'bg-red-500',
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  work: 'WORK',
+  internship: 'INTERNSHIP',
+  education: 'EDUCATION',
+  project: 'PROJECT',
+  award: 'AWARD',
+};
+
+export function BrutalistExperience() {
+  return (
+    <section
+      id="experience"
+      className="min-h-screen py-16 px-4 border-b-8 border-black dark:border-white bg-white dark:bg-black"
+    >
+      <div className="max-w-7xl mx-auto">
+        {/* Section Header */}
+        <div className="mb-12 bg-blue-500 p-8 border-8 border-black dark:border-white">
+          <h2 className="text-5xl lg:text-7xl font-black uppercase text-white">
+            EXPERIENCE<br />& EDUCATION
+          </h2>
+        </div>
+
+        {/* Timeline */}
+        <div className="space-y-8">
+          {sortedExperiences.map((exp, index) => {
+            const isEven = index % 2 === 0;
+            const colorClass = TYPE_COLORS[exp.type] || 'bg-gray-500';
+            const typeLabel = TYPE_LABELS[exp.type] || exp.type.toUpperCase();
+
+            return (
+              <div
+                key={exp.id}
+                className={`grid grid-cols-1 lg:grid-cols-2 gap-0 ${isEven ? '' : 'lg:flex-row-reverse'}`}
+              >
+                {/* Left: Type Badge & Period */}
+                <div
+                  className={`p-8 border-8 border-black dark:border-white ${colorClass} ${isEven ? '' : 'lg:order-2'}`}
+                >
+                  <div className="bg-black dark:bg-white px-4 py-2 border-4 border-black dark:border-white inline-block mb-4">
+                    <span className="text-white dark:text-black font-black text-xl">
+                      {typeLabel}
+                    </span>
+                  </div>
+
+                  <div className="text-3xl font-black text-black dark:text-white uppercase mb-2">
+                    {exp.period.start.substring(0, 7)}
+                    {exp.period.end ? ` — ${exp.period.end.substring(0, 7)}` : ' — PRESENT'}
+                  </div>
+
+                  {exp.location && (
+                    <div className="bg-white dark:bg-black p-3 border-4 border-black dark:border-white mt-4">
+                      <p className="text-black dark:text-white font-bold">📍 {exp.location}</p>
+                    </div>
+                  )}
+                </div>
+
+                {/* Right: Content */}
+                <div
+                  className={`p-8 border-8 border-black dark:border-white border-t-0 lg:border-t-8 ${isEven ? 'lg:border-l-0' : 'lg:border-r-0'} bg-white dark:bg-black ${isEven ? 'lg:order-2' : 'lg:order-1'}`}
+                >
+                  {/* Title & Company */}
+                  <h3 className="text-2xl lg:text-3xl font-black uppercase text-black dark:text-white mb-2">
+                    {exp.title}
+                  </h3>
+
+                  <div className="bg-yellow-300 dark:bg-yellow-600 px-4 py-2 border-4 border-black dark:border-white inline-flex items-center gap-2 mb-6">
+                    <span className="text-black dark:text-white font-black text-lg">
+                      {exp.company || exp.organization}
+                    </span>
+                    {exp.url && (
+                      <a
+                        href={exp.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:rotate-45 transition-transform"
+                      >
+                        <ExternalLink size={20} className="text-black dark:text-white" />
+                      </a>
+                    )}
+                  </div>
+
+                  {/* Description */}
+                  <div className="bg-gray-100 dark:bg-gray-900 p-4 border-4 border-black dark:border-white mb-4">
+                    <p className="text-black dark:text-white font-bold leading-relaxed">
+                      {exp.description}
+                    </p>
+                  </div>
+
+                  {/* Technologies */}
+                  {exp.technologies && exp.technologies.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-4">
+                      {exp.technologies.map((tech, i) => (
+                        <span
+                          key={i}
+                          className="bg-black dark:bg-white px-3 py-1 border-2 border-black dark:border-white text-white dark:text-black font-bold text-xs uppercase"
+                        >
+                          {tech}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Achievements */}
+                  {exp.achievements && exp.achievements.length > 0 && (
+                    <div className="space-y-2">
+                      {exp.achievements.map((achievement, i) => (
+                        <div
+                          key={i}
+                          className="bg-red-500 dark:bg-red-600 p-3 border-4 border-black dark:border-white"
+                        >
+                          <p className="text-white font-black text-sm">★ {achievement}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/brutalist/BrutalistGitHub.tsx
+++ b/src/components/brutalist/BrutalistGitHub.tsx
@@ -1,0 +1,183 @@
+import { useGitHub } from '@/hooks/useGitHub';
+import { ExternalLink, Star, GitFork, Code } from 'lucide-react';
+import { useMemo } from 'react';
+
+export function BrutalistGitHub() {
+  const { user, repos, totalContributions, loading, error } = useGitHub();
+
+  const stats = useMemo(() => {
+    const totalStars = repos.reduce((sum, repo) => sum + (repo.stargazers_count || 0), 0);
+    const totalForks = repos.reduce((sum, repo) => sum + (repo.forks_count || 0), 0);
+    const totalRepos = repos.filter((repo) => !repo.fork).length;
+
+    return {
+      totalRepos,
+      totalStars,
+      totalForks,
+      totalContributions,
+    };
+  }, [repos, totalContributions]);
+
+  if (loading) {
+    return (
+      <section className="min-h-screen py-16 px-4 bg-black dark:bg-white flex items-center justify-center">
+        <div className="text-6xl font-black text-white dark:text-black uppercase animate-pulse">
+          LOADING...
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="min-h-screen py-16 px-4 bg-red-500 flex items-center justify-center">
+        <div className="text-4xl font-black text-white uppercase text-center">
+          ERROR LOADING<br />GITHUB DATA
+        </div>
+      </section>
+    );
+  }
+
+  const topRepos = repos
+    .filter((repo) => !repo.fork)
+    .sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0))
+    .slice(0, 6);
+
+  return (
+    <section
+      id="github-activity"
+      className="min-h-screen py-16 px-4 bg-green-400 dark:bg-red-600"
+    >
+      <div className="max-w-7xl mx-auto">
+        {/* Section Header */}
+        <div className="mb-12 bg-black dark:bg-white p-8 border-8 border-black dark:border-white">
+          <h2 className="text-5xl lg:text-7xl font-black uppercase text-white dark:text-black">
+            GITHUB<br />ACTIVITY
+          </h2>
+        </div>
+
+        {/* Stats Grid */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
+          <div className="bg-red-500 p-6 border-8 border-black dark:border-white">
+            <div className="text-white font-black text-xs uppercase mb-2">
+              Total Repos
+            </div>
+            <div className="text-white font-black text-5xl">
+              {stats.totalRepos}
+            </div>
+          </div>
+
+          <div className="bg-yellow-400 p-6 border-8 border-black dark:border-white">
+            <div className="text-black font-black text-xs uppercase mb-2">
+              Total Stars
+            </div>
+            <div className="text-black font-black text-5xl">
+              {stats.totalStars}
+            </div>
+          </div>
+
+          <div className="bg-blue-500 p-6 border-8 border-black dark:border-white">
+            <div className="text-white font-black text-xs uppercase mb-2">
+              Total Forks
+            </div>
+            <div className="text-white font-black text-5xl">
+              {stats.totalForks}
+            </div>
+          </div>
+
+          <div className="bg-purple-600 p-6 border-8 border-black dark:border-white">
+            <div className="text-white font-black text-xs uppercase mb-2">
+              Contributions
+            </div>
+            <div className="text-white font-black text-5xl">
+              {stats.totalContributions}
+            </div>
+          </div>
+        </div>
+
+        {/* Popular Repositories */}
+        <div className="mb-12">
+          <div className="bg-blue-600 p-6 border-8 border-black dark:border-white mb-6">
+            <h3 className="text-3xl lg:text-4xl font-black uppercase text-white">
+              POPULAR REPOS
+            </h3>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {topRepos.map((repo) => (
+              <a
+                key={repo.id}
+                href={repo.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block"
+              >
+                <div className="bg-white dark:bg-black p-6 border-8 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform h-full flex flex-col">
+                  {/* Repo Name */}
+                  <div className="flex items-start justify-between mb-4">
+                    <h4 className="text-xl font-black uppercase text-black dark:text-white flex-1 break-words">
+                      {repo.name}
+                    </h4>
+                    <ExternalLink
+                      size={24}
+                      className="text-black dark:text-white group-hover:rotate-45 transition-transform flex-shrink-0 ml-2"
+                    />
+                  </div>
+
+                  {/* Description */}
+                  {repo.description && (
+                    <div className="bg-gray-100 dark:bg-gray-900 p-3 border-4 border-black dark:border-white mb-4 flex-1">
+                      <p className="text-sm font-bold text-black dark:text-white line-clamp-3">
+                        {repo.description}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Language */}
+                  {repo.language && (
+                    <div className="bg-yellow-300 dark:bg-yellow-600 px-3 py-2 border-4 border-black dark:border-white inline-block mb-4">
+                      <span className="text-black dark:text-white font-black text-xs uppercase flex items-center gap-2">
+                        <Code size={16} />
+                        {repo.language}
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Stats */}
+                  <div className="flex gap-4 mt-auto">
+                    <div className="bg-red-500 px-3 py-2 border-4 border-black dark:border-white flex items-center gap-2">
+                      <Star size={16} className="text-white" />
+                      <span className="text-white font-black text-sm">
+                        {repo.stargazers_count}
+                      </span>
+                    </div>
+                    <div className="bg-blue-500 px-3 py-2 border-4 border-black dark:border-white flex items-center gap-2">
+                      <GitFork size={16} className="text-white" />
+                      <span className="text-white font-black text-sm">
+                        {repo.forks_count}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* GitHub Profile Link */}
+        {user && (
+          <div className="text-center">
+            <a
+              href={user.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block bg-black dark:bg-white text-white dark:text-black px-12 py-6 border-8 border-black dark:border-white font-black text-2xl uppercase hover:translate-x-2 hover:translate-y-2 transition-transform"
+            >
+              VIEW ON GITHUB →
+            </a>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/brutalist/BrutalistHero.tsx
+++ b/src/components/brutalist/BrutalistHero.tsx
@@ -4,7 +4,7 @@ export function BrutalistHero() {
   return (
     <section
       id="hero"
-      className="min-h-screen pt-24 pb-12 px-4 border-b-8 border-black dark:border-white"
+      className="min-h-screen pt-32 md:pt-40 pb-12 px-4 border-b-8 border-black dark:border-white"
     >
       <div className="max-w-7xl mx-auto">
         {/* Grid Layout */}

--- a/src/components/brutalist/BrutalistHero.tsx
+++ b/src/components/brutalist/BrutalistHero.tsx
@@ -1,0 +1,94 @@
+import { Mail, Github, Linkedin, Twitter } from 'lucide-react';
+
+export function BrutalistHero() {
+  return (
+    <section
+      id="hero"
+      className="min-h-screen pt-24 pb-12 px-4 border-b-8 border-black dark:border-white"
+    >
+      <div className="max-w-7xl mx-auto">
+        {/* Grid Layout */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
+          {/* Left: Text Content */}
+          <div className="p-8 lg:p-12 border-8 border-black dark:border-white bg-yellow-300 dark:bg-blue-600">
+            <div className="space-y-6">
+              <h1 className="text-6xl lg:text-8xl font-black uppercase text-black dark:text-white leading-none">
+                JACKSON<br />CHEN
+              </h1>
+
+              <div className="bg-black dark:bg-white p-4 border-4 border-black dark:border-white">
+                <p className="text-xl lg:text-2xl font-bold text-white dark:text-black uppercase">
+                  FULL STACK DEVELOPER &<br />COMPUTER SCIENCE STUDENT
+                </p>
+              </div>
+
+              <div className="bg-white dark:bg-black p-6 border-4 border-black dark:border-white">
+                <p className="text-3xl lg:text-4xl font-black text-black dark:text-white italic">
+                  "I CAME,<br />I SAW,<br />I MADE IT."
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: About & Social */}
+          <div className="p-8 lg:p-12 border-8 border-black dark:border-white border-t-0 lg:border-t-8 lg:border-l-0 bg-white dark:bg-black">
+            <div className="space-y-6">
+              <div className="bg-red-500 p-6 border-4 border-black dark:border-white">
+                <h2 className="text-2xl font-black uppercase text-white mb-4">ABOUT</h2>
+                <div className="space-y-4 text-white font-bold">
+                  <p>
+                    I am a <span className="bg-black dark:bg-white text-white dark:text-black px-2 py-1">FULL STACK DEVELOPER</span> and also a student at the <span className="bg-black dark:bg-white text-white dark:text-black px-2 py-1">UNIVERSITY OF WISCONSIN-MADISON</span>, majoring in <span className="bg-black dark:bg-white text-white dark:text-black px-2 py-1">COMPUTER SCIENCE</span>.
+                  </p>
+                  <p>
+                    I'm an explorer of new tech, an <span className="bg-yellow-300 text-black px-2 py-1">AVID LEARNER</span>, and a <span className="bg-yellow-300 text-black px-2 py-1">PROBLEM-SOLVER</span> at heart.
+                  </p>
+                  <p>
+                    Moreover, I'm a <span className="bg-blue-500 text-white px-2 py-1">PASSIONATE PROGRAMMER</span> on earth. Feel free to connect with me for all things tech or just to say hello!
+                  </p>
+                </div>
+              </div>
+
+              {/* Social Links */}
+              <div className="grid grid-cols-2 gap-4">
+                <a
+                  href="https://github.com/Sma1lboy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-black dark:bg-white text-white dark:text-black p-4 border-4 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform flex items-center justify-center gap-2 font-bold uppercase"
+                >
+                  <Github size={24} />
+                  GITHUB
+                </a>
+                <a
+                  href="https://www.linkedin.com/in/jackson-chen-uwisc/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-600 text-white p-4 border-4 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform flex items-center justify-center gap-2 font-bold uppercase"
+                >
+                  <Linkedin size={24} />
+                  LINKEDIN
+                </a>
+                <a
+                  href="https://twitter.com/sma1lboy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-400 text-white p-4 border-4 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform flex items-center justify-center gap-2 font-bold uppercase"
+                >
+                  <Twitter size={24} />
+                  TWITTER
+                </a>
+                <a
+                  href="mailto:jacksonchen666666@gmail.com"
+                  className="bg-red-600 text-white p-4 border-4 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform flex items-center justify-center gap-2 font-bold uppercase"
+                >
+                  <Mail size={24} />
+                  EMAIL
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/brutalist/BrutalistHome.tsx
+++ b/src/components/brutalist/BrutalistHome.tsx
@@ -1,0 +1,21 @@
+import { BrutalistHero } from './BrutalistHero';
+import { BrutalistProjects } from './BrutalistProjects';
+import { BrutalistExperience } from './BrutalistExperience';
+import { BrutalistTechStack } from './BrutalistTechStack';
+import { BrutalistGitHub } from './BrutalistGitHub';
+import { BrutalistNav } from './BrutalistNav';
+
+export default function BrutalistHome() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-black font-mono">
+      <BrutalistNav />
+      <div className="brutalist-container">
+        <BrutalistHero />
+        <BrutalistProjects />
+        <BrutalistExperience />
+        <BrutalistTechStack />
+        <BrutalistGitHub />
+      </div>
+    </div>
+  );
+}

--- a/src/components/brutalist/BrutalistNav.tsx
+++ b/src/components/brutalist/BrutalistNav.tsx
@@ -1,0 +1,28 @@
+import { Link } from '@tanstack/react-router';
+import { useThemeStore } from '@/store/themeStore';
+
+export function BrutalistNav() {
+  const { resolvedTheme, toggleTheme } = useThemeStore();
+
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-black border-b-8 border-black dark:border-white">
+      <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            to="/"
+            className="px-6 py-3 bg-black dark:bg-white text-white dark:text-black font-bold text-xl border-4 border-black dark:border-white hover:translate-x-1 hover:translate-y-1 transition-transform uppercase"
+          >
+            ← CLASSIC
+          </Link>
+          <span className="text-2xl font-black uppercase">JACKSON CHEN</span>
+        </div>
+        <button
+          onClick={toggleTheme}
+          className="px-6 py-3 bg-yellow-400 text-black font-bold border-4 border-black dark:border-white hover:bg-yellow-300 transition-colors uppercase"
+        >
+          {resolvedTheme === 'dark' ? '☀' : '🌙'} {resolvedTheme === 'dark' ? 'LIGHT' : 'DARK'}
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/brutalist/BrutalistProjects.tsx
+++ b/src/components/brutalist/BrutalistProjects.tsx
@@ -1,0 +1,69 @@
+import { featuredProjects } from '@/constants/home';
+import { ExternalLink } from 'lucide-react';
+
+const COLORS = ['bg-red-500', 'bg-blue-500', 'bg-yellow-400', 'bg-green-500', 'bg-purple-500'];
+
+export function BrutalistProjects() {
+  return (
+    <section
+      id="projects"
+      className="min-h-screen py-16 px-4 border-b-8 border-black dark:border-white bg-gray-100 dark:bg-gray-900"
+    >
+      <div className="max-w-7xl mx-auto">
+        {/* Section Header */}
+        <div className="mb-12 bg-black dark:bg-white p-8 border-8 border-black dark:border-white">
+          <h2 className="text-5xl lg:text-7xl font-black uppercase text-white dark:text-black">
+            SELECTED<br />WORK
+          </h2>
+        </div>
+
+        {/* Projects Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {featuredProjects.map((project, index) => (
+            <a
+              key={project.id}
+              href={project.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block"
+            >
+              <div
+                className={`${COLORS[index % COLORS.length]} p-8 border-8 border-black dark:border-white hover:translate-x-2 hover:translate-y-2 transition-transform h-full`}
+              >
+                {/* Year Badge */}
+                <div className="inline-block bg-black dark:bg-white px-4 py-2 border-4 border-black dark:border-white mb-4">
+                  <span className="text-white dark:text-black font-black text-xl">
+                    {project.year}
+                  </span>
+                </div>
+
+                {/* Title */}
+                <h3 className="text-3xl lg:text-4xl font-black uppercase text-black dark:text-white mb-4 flex items-center gap-2">
+                  {project.title}
+                  <ExternalLink
+                    size={32}
+                    className="group-hover:rotate-45 transition-transform"
+                  />
+                </h3>
+
+                {/* Description */}
+                <div className="bg-white dark:bg-black p-4 border-4 border-black dark:border-white mb-4">
+                  <p className="text-black dark:text-white font-bold leading-relaxed">
+                    {project.description}
+                  </p>
+                </div>
+
+                {/* Tech Stack */}
+                <div className="bg-black dark:bg-white p-4 border-4 border-black dark:border-white">
+                  <p className="text-white dark:text-black font-black uppercase text-sm">
+                    {project.tech}
+                  </p>
+                </div>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/brutalist/BrutalistTechStack.tsx
+++ b/src/components/brutalist/BrutalistTechStack.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+
+type TechCategory =
+  | 'Languages'
+  | 'Frontend'
+  | 'Backend'
+  | 'DevOps'
+  | 'Database'
+  | 'Services'
+  | 'AI/ML'
+  | 'Graphics';
+
+interface TechItem {
+  name: string;
+  category: TechCategory;
+  level: 'Expert' | 'Advanced' | 'Intermediate' | 'Familiar';
+}
+
+const techStack: TechItem[] = [
+  // Programming Languages
+  { name: 'TypeScript', category: 'Languages', level: 'Expert' },
+  { name: 'JavaScript', category: 'Languages', level: 'Expert' },
+  { name: 'Java', category: 'Languages', level: 'Expert' },
+  { name: 'Python', category: 'Languages', level: 'Advanced' },
+  { name: 'C++', category: 'Languages', level: 'Advanced' },
+  { name: 'Rust', category: 'Languages', level: 'Advanced' },
+  { name: 'C', category: 'Languages', level: 'Intermediate' },
+  { name: 'Go', category: 'Languages', level: 'Intermediate' },
+  { name: 'Swift', category: 'Languages', level: 'Intermediate' },
+  { name: 'C#', category: 'Languages', level: 'Familiar' },
+  { name: 'PHP', category: 'Languages', level: 'Familiar' },
+  { name: 'Ruby', category: 'Languages', level: 'Familiar' },
+
+  // Frontend
+  { name: 'React', category: 'Frontend', level: 'Expert' },
+  { name: 'Next.js', category: 'Frontend', level: 'Advanced' },
+  { name: 'Vite', category: 'Frontend', level: 'Advanced' },
+  { name: 'Tailwind CSS', category: 'Frontend', level: 'Advanced' },
+  { name: 'Framer Motion', category: 'Frontend', level: 'Advanced' },
+  { name: 'TanStack Router', category: 'Frontend', level: 'Advanced' },
+  { name: 'HTML/CSS', category: 'Frontend', level: 'Expert' },
+  { name: 'Vue.js', category: 'Frontend', level: 'Intermediate' },
+  { name: 'React Native', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Sass/SCSS', category: 'Frontend', level: 'Advanced' },
+  { name: 'Styled Components', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Material-UI', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Ant Design', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Bootstrap', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Webpack', category: 'Frontend', level: 'Intermediate' },
+  { name: 'ESLint', category: 'Frontend', level: 'Advanced' },
+  { name: 'Prettier', category: 'Frontend', level: 'Advanced' },
+  { name: 'Jest', category: 'Frontend', level: 'Intermediate' },
+  { name: 'React Testing Library', category: 'Frontend', level: 'Intermediate' },
+  { name: 'Storybook', category: 'Frontend', level: 'Familiar' },
+
+  // Backend & Frameworks
+  { name: 'Spring Boot', category: 'Backend', level: 'Advanced' },
+  { name: 'Node.js', category: 'Backend', level: 'Advanced' },
+  { name: 'ASP.NET Core', category: 'Backend', level: 'Advanced' },
+  { name: 'Express.js', category: 'Backend', level: 'Intermediate' },
+  { name: 'FastAPI', category: 'Backend', level: 'Intermediate' },
+  { name: 'Actix Web', category: 'Backend', level: 'Intermediate' },
+  { name: 'Spring Cloud', category: 'Backend', level: 'Intermediate' },
+  { name: 'Microservices', category: 'Backend', level: 'Advanced' },
+  { name: 'Spring Security', category: 'Backend', level: 'Advanced' },
+  { name: 'Spring Data JPA', category: 'Backend', level: 'Advanced' },
+  { name: 'Hibernate', category: 'Backend', level: 'Advanced' },
+  { name: 'MyBatis', category: 'Backend', level: 'Intermediate' },
+  { name: 'Entity Framework', category: 'Backend', level: 'Intermediate' },
+  { name: 'Nest.js', category: 'Backend', level: 'Intermediate' },
+  { name: 'Koa.js', category: 'Backend', level: 'Familiar' },
+  { name: 'Django', category: 'Backend', level: 'Intermediate' },
+  { name: 'Flask', category: 'Backend', level: 'Intermediate' },
+  { name: 'RESTful APIs', category: 'Backend', level: 'Expert' },
+  { name: 'GraphQL', category: 'Backend', level: 'Intermediate' },
+  { name: 'gRPC', category: 'Backend', level: 'Intermediate' },
+  { name: 'WebSocket', category: 'Backend', level: 'Intermediate' },
+  { name: 'JWT', category: 'Backend', level: 'Advanced' },
+  { name: 'OAuth 2.0', category: 'Backend', level: 'Intermediate' },
+
+  // Tools & DevOps
+  { name: 'Docker', category: 'DevOps', level: 'Advanced' },
+  { name: 'Git', category: 'DevOps', level: 'Expert' },
+  { name: 'GitHub Actions', category: 'DevOps', level: 'Intermediate' },
+  { name: 'CMake', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Kubernetes', category: 'DevOps', level: 'Familiar' },
+  { name: 'AWS', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Vercel', category: 'DevOps', level: 'Advanced' },
+  { name: 'Railway', category: 'DevOps', level: 'Advanced' },
+  { name: 'Netlify', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Heroku', category: 'DevOps', level: 'Intermediate' },
+  { name: 'DigitalOcean', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Eureka', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Spring Cloud Gateway', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Nginx', category: 'DevOps', level: 'Intermediate' },
+  { name: 'Apache', category: 'DevOps', level: 'Familiar' },
+
+  // Databases
+  { name: 'PostgreSQL', category: 'Database', level: 'Intermediate' },
+  { name: 'MySQL', category: 'Database', level: 'Intermediate' },
+  { name: 'MongoDB', category: 'Database', level: 'Advanced' },
+  { name: 'SQLite', category: 'Database', level: 'Intermediate' },
+  { name: 'Redis', category: 'Database', level: 'Intermediate' },
+  { name: 'Elasticsearch', category: 'Database', level: 'Intermediate' },
+
+  // Third-party Services & APIs
+  { name: 'Resend', category: 'Services', level: 'Advanced' },
+  { name: 'Stripe', category: 'Services', level: 'Intermediate' },
+  { name: 'Auth0', category: 'Services', level: 'Intermediate' },
+  { name: 'Clerk', category: 'Services', level: 'Intermediate' },
+  { name: 'Supabase', category: 'Services', level: 'Advanced' },
+  { name: 'Firebase', category: 'Services', level: 'Intermediate' },
+  { name: 'Twilio', category: 'Services', level: 'Familiar' },
+  { name: 'SendGrid', category: 'Services', level: 'Intermediate' },
+  { name: 'Cloudinary', category: 'Services', level: 'Intermediate' },
+  { name: 'Sentry', category: 'Services', level: 'Intermediate' },
+
+  // Specialized
+  { name: 'Machine Learning', category: 'AI/ML', level: 'Intermediate' },
+  { name: 'PyTorch', category: 'AI/ML', level: 'Intermediate' },
+  { name: 'TensorFlow', category: 'AI/ML', level: 'Familiar' },
+  { name: 'LLM Development', category: 'AI/ML', level: 'Advanced' },
+  { name: 'Computer Graphics', category: 'Graphics', level: 'Advanced' },
+  { name: 'Ray Tracing', category: 'Graphics', level: 'Advanced' },
+  { name: 'OpenGL', category: 'Graphics', level: 'Intermediate' },
+];
+
+const categories = [
+  'All',
+  'Languages',
+  'Frontend',
+  'Backend',
+  'DevOps',
+  'Database',
+  'Services',
+  'AI/ML',
+  'Graphics',
+];
+
+const LEVEL_COLORS: Record<string, string> = {
+  Expert: 'bg-red-500',
+  Advanced: 'bg-yellow-400',
+  Intermediate: 'bg-blue-500',
+  Familiar: 'bg-green-500',
+};
+
+export function BrutalistTechStack() {
+  const [selectedCategory, setSelectedCategory] = useState('All');
+
+  const filteredTech =
+    selectedCategory === 'All'
+      ? techStack
+      : techStack.filter((tech) => tech.category === selectedCategory);
+
+  const groupedByLevel = filteredTech.reduce(
+    (acc, tech) => {
+      if (!acc[tech.level]) {
+        acc[tech.level] = [];
+      }
+      acc[tech.level].push(tech);
+      return acc;
+    },
+    {} as Record<string, TechItem[]>,
+  );
+
+  return (
+    <section
+      id="tech-stack"
+      className="min-h-screen py-16 px-4 border-b-8 border-black dark:border-white bg-yellow-200 dark:bg-purple-900"
+    >
+      <div className="max-w-7xl mx-auto">
+        {/* Section Header */}
+        <div className="mb-12 bg-purple-600 p-8 border-8 border-black dark:border-white">
+          <h2 className="text-5xl lg:text-7xl font-black uppercase text-white">
+            TECH<br />STACK
+          </h2>
+        </div>
+
+        {/* Category Filter */}
+        <div className="mb-8 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+          {categories.map((category) => (
+            <button
+              key={category}
+              onClick={() => setSelectedCategory(category)}
+              className={`p-4 border-6 border-black dark:border-white font-black text-lg uppercase transition-transform hover:scale-105 ${
+                selectedCategory === category
+                  ? 'bg-black dark:bg-white text-white dark:text-black scale-105'
+                  : 'bg-white dark:bg-black text-black dark:text-white'
+              }`}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+
+        {/* Tech by Level */}
+        <div className="space-y-8">
+          {['Expert', 'Advanced', 'Intermediate', 'Familiar'].map((level) => {
+            const techs = groupedByLevel[level] || [];
+            if (techs.length === 0) return null;
+
+            return (
+              <div key={level}>
+                {/* Level Header */}
+                <div
+                  className={`${LEVEL_COLORS[level]} p-6 border-8 border-black dark:border-white mb-4`}
+                >
+                  <h3 className="text-3xl lg:text-4xl font-black uppercase text-black dark:text-white">
+                    {level} ({techs.length})
+                  </h3>
+                </div>
+
+                {/* Tech Items */}
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                  {techs.map((tech) => (
+                    <div
+                      key={tech.name}
+                      className="bg-white dark:bg-black p-4 border-4 border-black dark:border-white hover:translate-x-1 hover:translate-y-1 transition-transform"
+                    >
+                      <p className="text-black dark:text-white font-black text-center uppercase text-sm">
+                        {tech.name}
+                      </p>
+                      <p className="text-gray-600 dark:text-gray-400 font-bold text-center text-xs mt-1">
+                        {tech.category}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/brutalist/index.ts
+++ b/src/components/brutalist/index.ts
@@ -1,0 +1,7 @@
+export { default as BrutalistHome } from './BrutalistHome';
+export { BrutalistNav } from './BrutalistNav';
+export { BrutalistHero } from './BrutalistHero';
+export { BrutalistProjects } from './BrutalistProjects';
+export { BrutalistExperience } from './BrutalistExperience';
+export { BrutalistTechStack } from './BrutalistTechStack';
+export { BrutalistGitHub } from './BrutalistGitHub';

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { sortedExperiences } from "../../constants/experiences";
 import { ExperienceSection } from "./ExperienceSection";
 import { GitHubActivitySection } from "./GitHubActivitySection";
@@ -75,6 +76,14 @@ export function Home({ ...rest }: Props) {
       </div>
 
       <NavigationDock activeSection={activeSection} scrollToSection={scrollToSection} />
+
+      {/* Brutalist Version Link */}
+      <Link
+        to="/new"
+        className="fixed bottom-24 right-6 z-40 bg-yellow-400 text-black px-6 py-3 font-black text-sm uppercase border-4 border-black dark:border-white hover:translate-x-1 hover:translate-y-1 transition-transform shadow-lg"
+      >
+        🎨 BRUTALIST
+      </Link>
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -306,4 +306,14 @@
   .scrollbar-hide::-webkit-scrollbar {
     display: none; /* Safari and Chrome */
   }
+
+  /* Brutalist design utilities */
+  .brutalist-container {
+    font-family: 'Courier New', monospace;
+  }
+
+  /* Brutalist border utility */
+  .border-6 {
+    border-width: 6px;
+  }
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProfileRouteImport } from './routes/profile'
+import { Route as NewRouteImport } from './routes/new'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 
 const ProfileRoute = ProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NewRoute = NewRouteImport.update({
+  id: '/new',
+  path: '/new',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -32,30 +38,34 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/new': typeof NewRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/new': typeof NewRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/new': typeof NewRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/$' | '/profile'
+  fullPaths: '/' | '/$' | '/new' | '/profile'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/$' | '/profile'
-  id: '__root__' | '/' | '/$' | '/profile'
+  to: '/' | '/$' | '/new' | '/profile'
+  id: '__root__' | '/' | '/$' | '/new' | '/profile'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  NewRoute: typeof NewRoute
   ProfileRoute: typeof ProfileRoute
 }
 
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/profile'
       fullPath: '/profile'
       preLoaderRoute: typeof ProfileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/new': {
+      id: '/new'
+      path: '/new'
+      fullPath: '/new'
+      preLoaderRoute: typeof NewRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$': {
@@ -88,6 +105,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  NewRoute: NewRoute,
   ProfileRoute: ProfileRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/new.tsx
+++ b/src/routes/new.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import BrutalistHome from '@/components/brutalist/BrutalistHome';
+
+export const Route = createFileRoute('/new')({
+  component: NewPage,
+});
+
+function NewPage() {
+  return <BrutalistHome />;
+}


### PR DESCRIPTION
- Created new /new route with complete brutalist design style
- Implemented all 5 main sections with brutalist aesthetics:
  * Hero section with bold typography and bright colors
  * Projects section with vibrant color-coded cards
  * Experience section with alternating grid layout
  * Tech Stack section with category filters
  * GitHub Activity section with live stats

- Added brutalist navigation bar with theme toggle
- Included bidirectional navigation between classic and brutalist versions
- Preserved all original content and functionality
- Applied brutalist design principles:
  * Bold, thick borders (8px black/white borders)
  * High contrast colors (red, blue, yellow, green, purple)
  * Monospace font family
  * Flat design with minimal shadows
  * Grid-based asymmetric layouts
  * Minimal animations (only hover translations)

All original features remain functional:
- GitHub API integration
- Dark mode support
- Responsive design
- Tech stack filtering
- Social links