### PR TITLE
feat: add artifact-share to the product ledger

### DIFF
--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -85,12 +85,24 @@ export const products: Entry[] = [
     name: "brand-studio",
     href: "https://brand-studio.sma1lboy.me",
     pitch:
-      "generate → review → settle: brand assets as a pipeline, round boards and a share server",
+      "generate → review → settle: brand assets as a repeatable pipeline — it curates and seals, producers generate, humans gate every round",
     repo: "https://github.com/Sma1lboy/brand-studio",
     stars: 3,
     lang: "Python",
     year: "2026",
     live: true,
+    tier: 2,
+  },
+  {
+    name: "artifact-share",
+    href: "https://share.sma1lboy.me",
+    pitch:
+      "publish an HTML page, get the verdicts back — one POST turns a self-contained board into a public review link the agent reads as JSON",
+    repo: "https://github.com/Sma1lboy/artifact-share",
+    lang: "JavaScript",
+    year: "2026",
+    live: true,
+    note: "~200 lines",
     tier: 2,
   },
   {


### PR DESCRIPTION
artifact-share split out of brand-studio into [its own repo](https://github.com/Sma1lboy/artifact-share) and is live at **share.sma1lboy.me** — publish a self-contained HTML page, reviewers decide in the browser, the agent reads the verdicts back as JSON. Cloudflare Worker + KV, ~200 lines.

Also updates brand-studio's pitch: it no longer ships the share server (that's now a submodule), so "and a share server" is retired in favor of what the skill actually is.

`npm run build` and `npm run prettier` both clean.