### PR TITLE
fix: unbreak the Vercel build — install with npm, run on Node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "vite": "^6.0.11",
     "vite-plugin-compression2": "^1.3.3",
     "vite-plugin-inspect": "^11.0.1"
+  },
+  "engines": {
+    "node": "24.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm install --no-audit --no-fund",
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }


### PR DESCRIPTION
`main` has not built on Vercel since **9 Aug**. Every PR since then, including [#73](https://github.com/Sma1lboy/sma1lboy.me/pull/73), has been blocked by it.

## What was wrong

`.gitignore` excludes `package-lock.json` and tracks `bun.lock`, so Vercel's auto-detection picked bun. Bun then could not reach the npm registry from its build container:

```
error: ConnectionRefused downloading tarball zustand@5.0.6
error: FailedToOpenSocket downloading tarball semver@7.7.2
…
Error: Command "bun install" exited with 1
```

**546 packages, all of them failing** — not one bad dependency, the whole registry unreachable. This is a [known bun issue in containerised builds](https://github.com/oven-sh/bun/issues/22761), and Vercel pins its own bun version, so we can't outrun it from here.

## The fix

Pin `installCommand` so nothing is inferred:

```json
"installCommand": "npm install --no-audit --no-fund"
```

Verified against real Vercel deploys, not locally:

| | before | after |
| --- | --- | --- |
| install | 546 tarballs fail | `added 551 packages in 12s` |
| build | never reached | `✓ built in 4.56s` |

`package-lock.json` stays gitignored — `npm install` resolves from `package.json` fine, and adding a second tracked lockfile would just recreate the ambiguity that caused this.

## Also: Node 24

The project was on **20.x**, which Vercel deprecates on **2026-10-01** — it would have broken the build a second time. `engines.node` is pinned to `24.x` (not `>=22`, which Vercel warns will auto-upgrade on each new major). Confirmed in the deploy log: `Node.js version changed from "20.x" to "24.x"`, and the deprecation warning is gone.

Local `npm run build` and `npm run prettier` both clean.