### PR TITLE
chore: gitignore registry config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ bun.lockb
 yarn.lock
 package-lock.json
 
+# Registry credentials. Also keeps a private mirror from being pinned here —
+# that's how bun.lock ended up full of internal URLs no CI could resolve (#75).
+.npmrc
+.yarnrc
+.yarnrc.yml
+
 auto-imports.d.ts
 .eslintrc-auto-import.json
 .gstack/


### PR DESCRIPTION
Follow-up to #75.

`.npmrc` carries an npm auth token, and a registry pinned in one is exactly what put 631 `bnpm.byted.org` URLs into `bun.lock` — a private mirror's topology baked into the repo, unresolvable from any CI. Neither failure mode should be one stray `git add` away.

```
.npmrc
.yarnrc
.yarnrc.yml
```

`bunfig.toml` is deliberately **not** listed: it carries ordinary build settings (test timeouts, preloads) that are worth committing, and ignoring it would make a future one silently vanish. This repo has never had one.

Verified the rule actually bites rather than just reading right:

```
$ echo "registry=https://evil.example.com" > .npmrc
$ git check-ignore -v .npmrc
.gitignore:38:.npmrc	.npmrc      ← blocked, absent from git status
$ touch bunfig.toml && git check-ignore -q bunfig.toml
                                          ← not blocked, still committable
```